### PR TITLE
Fix datepicker in small views

### DIFF
--- a/sass/react-datepicker.scss
+++ b/sass/react-datepicker.scss
@@ -72,7 +72,7 @@
   display: inline-block;
   position: relative;
   width:20rem;
-  height:20rem;
+  height:21rem;
 }
 
 .react-datepicker__triangle {
@@ -81,7 +81,7 @@
 }
 
 .react-datepicker-popper {
-  z-index: 1;
+  z-index: 10;
 }
 
 .react-datepicker-popper[data-placement^="bottom"] {


### PR DESCRIPTION
**Issue:**
On small screens (mobile or resized windows) the datepicker gets overlap by the paging buttons. 
**Cause:** 
The buttons have a higher z-index (2) than the datepicker (1).
**Solution:**
Modify z-index for datepicker to avoid overlapping issues.
**PS:** 
Also the height of the calendar has been increased from 20 to 21rem to avoid issues with cut-out days.

**Screenshots** 
<img width="756" alt="screen shot 2017-08-16 at 08 28 53" src="https://user-images.githubusercontent.com/5918438/29350612-88be7a5a-825f-11e7-8e8b-6addaffe33d5.png">

<img width="1280" alt="screen shot 2017-08-16 at 08 28 43 2" src="https://user-images.githubusercontent.com/5918438/29350619-8fb7d310-825f-11e7-94fb-1951aa53e688.png">

