### PR TITLE
Remove comma on years in the line chart. Fix issue with datepicker no…

### DIFF
--- a/app/components/search/DatePickerSelector.jsx
+++ b/app/components/search/DatePickerSelector.jsx
@@ -13,7 +13,9 @@ class DatePickerSelector extends React.Component {
         }
         this.state = {
             startDate: startDate,
-            endDate: endDate
+            endDate: endDate,
+            minDate: startDate,
+            maxDate: endDate
         };
 
         this.startingDateChanged = this.startingDateChanged.bind(this);
@@ -39,9 +41,7 @@ class DatePickerSelector extends React.Component {
                             selected={this.state.startDate}
                             selectsStart
                             startDate={this.state.startDate}
-                            endDate={this.state.endDate}
-                            minDate={this.state.startDate}
-                            maxDate={this.state.endDate}
+                            minDate={this.state.minDate}
                             onChange={this.startingDateChanged}
                             showMonthDropdown
                             showYearDropdown
@@ -54,9 +54,7 @@ class DatePickerSelector extends React.Component {
                             selected={this.state.endDate}
                             selectsEnd
                             startDate={this.state.startDate}
-                            endDate={this.state.endDate}
-                            minDate={this.state.startDate}
-                            maxDate={this.state.endDate}
+                            maxDate={this.state.maxDate}
                             onChange={this.endDateChanged}
                             showMonthDropdown
                             showYearDropdown

--- a/app/components/stats/QueryComparisonLineChart.jsx
+++ b/app/components/stats/QueryComparisonLineChart.jsx
@@ -98,6 +98,7 @@ class QueryComparisonLineChart extends React.Component {
 		const xAxis = d3.axisBottom()
 			.scale(x)
 			.tickSize(-height, 0)
+            .tickFormat(d3.format("d"));
 
 		const yAxis = d3.axisLeft()
 			.scale(y)


### PR DESCRIPTION
This are some minor updates and fixes:

- Remove comma on years in the line chart.

- Fix issue with datepicker not allowing user to go back in date. 

- Remove log message from QueryBuilder