### PR TITLE
#130 Remove collection metadata tickbox from current search interface

### DIFF
--- a/app/components/search/QueryBuilder.jsx
+++ b/app/components/search/QueryBuilder.jsx
@@ -412,13 +412,16 @@ class QueryBuilder extends React.Component {
 						</label>
 					)
 				})
-				if(layers) {
-					layerOptions = (
-						<div className={IDUtil.cssClassName('search-layers', this.CLASS_PREFIX)}>
-							{layers}
-						</div>
-					)
-				}
+				// Hide collection metada tickbox from current search interface.
+				//https://github.com/CLARIAH/wp5_mediasuite/issues/130
+				// it could be enabled once we have more options to provide.
+				// if(layers) {
+				// 	layerOptions = (
+				// 		<div className={IDUtil.cssClassName('search-layers', this.CLASS_PREFIX)}>
+				// 			{layers}
+				// 		</div>
+				// 	)
+				// }
 			}
 
 			//only draw this when there are search results
@@ -555,7 +558,7 @@ class QueryBuilder extends React.Component {
 						</div>
 					</div>
 					<div className="separator"></div>
-					{layerOptions}
+					{/*{layerOptions}*/}
 					<div className="separator"></div>
 					{resultBlock}
 				</div>


### PR DESCRIPTION
Remove collection metadata tickbox from current search interface.
This functionality has been 'temporarily disabled'