### PR TITLE
Issue #93. Highlight searched term in result snippet

### DIFF
--- a/app/components/search/SearchSnippet.jsx
+++ b/app/components/search/SearchSnippet.jsx
@@ -22,6 +22,18 @@ class SearchSnippet extends React.Component {
 		return mediaTypes
 	}
 
+    highlightSearchedTerm(text) {
+		if(text === null) {
+		 	return text
+		}
+        let regex = new RegExp(this.props.searchTerm, 'gi');
+
+        return text.replace(regex, (term) => "<span class='highLightText'>" + term + "</span>");
+    }
+
+    createMarkup(text){
+		return {__html: text}
+	}
 	//possible default fields: posterURL, title, description, tags
 	render() {
 		let poster = null;
@@ -101,24 +113,28 @@ class SearchSnippet extends React.Component {
 		}
 
 		//generate main classes
-		const classNames = ['media', IDUtil.cssClassName('search-snippet')]
+        const classNames = ['media', IDUtil.cssClassName('search-snippet')],
+            title = this.props.data.title ? this.props.data.title + ' ' : '',
+            date = this.props.data.date ? '(' + this.props.data.date + ')' : '';
 
-		return (
+        return (
 			<div className={classNames.join(' ')}>
 				<div className="media-left">
 					{poster}
 				</div>
-				<div className="media-body">
+				<div  className="media-body">
 					<h4 className="media-heading custom-pointer" title={this.props.data.id}>
-						{this.props.data.title ? this.props.data.title + ' ' : ''}
-						{this.props.data.date ? '(' + this.props.data.date + ')' : ''}
+						<span dangerouslySetInnerHTML={this.createMarkup(this.highlightSearchedTerm(title))}></span>
+						{date}
 						&nbsp;{mediaTypes}&nbsp;{accessIcon}&nbsp;{fragmentIcon}
 					</h4>
-					{CollectionUtil.highlightSearchTermInDescription(
-						this.props.data.description,
-						this.props.searchTerm,
-						35
-					)}
+					<span className="snippet_description" dangerouslySetInnerHTML={this.createMarkup(
+                        this.highlightSearchedTerm(CollectionUtil.highlightSearchTermInDescription(
+                            this.props.data.description,
+                            this.props.searchTerm,
+                            35
+                        ))
+					)} />
 					{fragmentInfo}
 					{tags}
 				</div>

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -283,6 +283,15 @@
 			font-style:italic;
 			margin-top:5px;
 		}
+
+		.highLightText {
+			color: #f26c50;
+			font-weight: bold;
+			font-size: 97%;
+		}
+		.snippet_description:hover {
+			cursor: pointer;
+		}
 	}
 	&.fragment { /* possibly change this into .bg__search-hit--fragment (BEM style) */
 		border-right: 1px solid $highlight-color;


### PR DESCRIPTION
Issue #93. Highlight searched term in result snippet.
https://github.com/CLARIAH/wp5_mediasuite/issues/93 
Scope of issue updated by @liliana to focus only in the snippets and not in the 'resource viewer'.
