### PR TITLE
Updated the selected facets list

### DIFF
--- a/app/components/search/AggregationList.jsx
+++ b/app/components/search/AggregationList.jsx
@@ -83,8 +83,8 @@ class AggregationList extends React.Component {
     }
 
     switchListView(index) {
-        const btnText = document.querySelectorAll("#index__" + index + " .switchViewText")[0].textContent,
-            jCurrentList = Array.from(document.querySelectorAll("#index__" + index + " ul > li[class='bg__agl__facet-item']"));
+        const btnText = document.querySelectorAll("#index__" + index + " .switchViewText")[0].textContent
+        const jCurrentList = Array.from(document.querySelectorAll("#index__" + index + " ul > li[class='bg__agl__facet-item']"));
         let currentlyChecked = 0;
 
         if (btnText === "Show More") {
@@ -99,7 +99,7 @@ class AggregationList extends React.Component {
             });
         } else {
             // hide elements after clicking Show Less based on min already set or the current number of selected opts.
-            currentlyChecked = document.querySelectorAll("#index__" + index + ' input[type="checkbox"]:checked').length;
+            //currentlyChecked = document.querySelectorAll("#index__" + index + ' input[type="checkbox"]:checked').length;
             currentlyChecked = currentlyChecked > this.minToShow ? currentlyChecked : this.minToShow;
             jCurrentList.map((item, index) => {
                 if (index >= currentlyChecked) {
@@ -124,6 +124,11 @@ class AggregationList extends React.Component {
             }
         }
         this.onOutput(desiredFacets, this.props.selectedFacets);
+    }
+
+    hideZero(arr, selectedCategory) {
+        console.log("Hide!");
+        console.log(arr);
     }
 
     sorting(arr, order="asc", type="alpha", index){
@@ -159,7 +164,7 @@ class AggregationList extends React.Component {
         const facets = [],
             nonDateAggregations = this.props.desiredFacets.filter(aggr => aggr.type !== 'date_histogram');
         let aggregationCreatorModal = null,
-            selectedOpts = [],
+            selectedOpts = {},
             nrCheckedOpts = 0,
             opts = [],
             emptyAggregations = [],
@@ -191,10 +196,7 @@ class AggregationList extends React.Component {
 
                     if (this.props.selectedFacets[key['field']]) {
                         if (checkedOpt = this.props.selectedFacets[key['field']].indexOf(value) > -1) {
-                            selectedOpts.push({
-                                'name': facet.key,
-                                'hits': facet.doc_count
-                            });
+                            selectedOpts[facet.key] = facet.doc_count;
                             nrCheckedOpts++;
                         }
                     }
@@ -297,6 +299,8 @@ class AggregationList extends React.Component {
                                     <i className="fa fa-sort-numeric-asc fa-lg" aria-hidden="true"></i> </li>
                                 <li title="Numeric descending" onClick={this.sorting.bind(this, this.props.aggregations[key['field']], 'desc', "non-alpha", key['field'])}>
                                     <i className="fa fa-sort-numeric-desc fa-lg" aria-hidden="true"></i> </li>
+                                <li title="Hide/Unhide empty filters" onClick={this.hideZero.bind(this, this.props.aggregations[key['field']], key['field'])}>
+                                    <i className="fa fa-times-circle-o" aria-hidden="true"> </i> </li>
                                 <li title="Download as CSV" onClick={this.sorting.bind(this, this.props.aggregations[key['field']], 'desc', "non-alpha", key['field'])}>
                                     <CSVLink filename={facetName} headers={headers} data={this.props.aggregations[key['field']]} >
                                         <i className="fa fa-download" aria-hidden="true"></i>
@@ -311,14 +315,23 @@ class AggregationList extends React.Component {
                         <ReactTooltip id={'tooltip__' + index}/>
                     </div>
                 ))
-                selectedOpts.forEach((facet, index) => {
-                    opts.push(
+
+                //List of selected facets on top
+                if (this.props.selectedFacets.hasOwnProperty(key['field'])) {
+                    for (var entry in this.props.selectedFacets[key['field']]) {
+                        var facetName = this.props.selectedFacets[key['field']][entry];
+                        var hits = 0
+                        if (selectedOpts.hasOwnProperty(facetName)) {
+                            var hits = selectedOpts[facetName];
+                        }
+                        opts.push(
                         <div className={IDUtil.cssClassName('selected-item', this.CLASS_PREFIX)}>
-                            {facet.name.toUpperCase()} ({facet.hits})
-                            <span className="fa fa-remove" onClick={this.toggleSelectedFacet.bind(this, key['field'], facet.name)}/>
+                            {facetName.toUpperCase()} ({hits})
+                            <span className="fa fa-remove" onClick={this.toggleSelectedFacet.bind(this, key['field'], facetName)}/>
                         </div>
-                    )
-                });
+                        )
+                    }
+                }
             }
             nrCheckedOpts = 0;
             selectedOpts = [];

--- a/app/components/search/AggregationList.jsx
+++ b/app/components/search/AggregationList.jsx
@@ -99,7 +99,7 @@ class AggregationList extends React.Component {
             });
         } else {
             // hide elements after clicking Show Less based on min already set or the current number of selected opts.
-            //currentlyChecked = document.querySelectorAll("#index__" + index + ' input[type="checkbox"]:checked').length;
+            currentlyChecked = document.querySelectorAll("#index__" + index + ' input[type="checkbox"]:checked').length;
             currentlyChecked = currentlyChecked > this.minToShow ? currentlyChecked : this.minToShow;
             jCurrentList.map((item, index) => {
                 if (index >= currentlyChecked) {
@@ -124,11 +124,6 @@ class AggregationList extends React.Component {
             }
         }
         this.onOutput(desiredFacets, this.props.selectedFacets);
-    }
-
-    hideZero(arr, selectedCategory) {
-        console.log("Hide!");
-        console.log(arr);
     }
 
     sorting(arr, order="asc", type="alpha", index){
@@ -299,8 +294,6 @@ class AggregationList extends React.Component {
                                     <i className="fa fa-sort-numeric-asc fa-lg" aria-hidden="true"></i> </li>
                                 <li title="Numeric descending" onClick={this.sorting.bind(this, this.props.aggregations[key['field']], 'desc', "non-alpha", key['field'])}>
                                     <i className="fa fa-sort-numeric-desc fa-lg" aria-hidden="true"></i> </li>
-                                <li title="Hide/Unhide empty filters" onClick={this.hideZero.bind(this, this.props.aggregations[key['field']], key['field'])}>
-                                    <i className="fa fa-times-circle-o" aria-hidden="true"> </i> </li>
                                 <li title="Download as CSV" onClick={this.sorting.bind(this, this.props.aggregations[key['field']], 'desc', "non-alpha", key['field'])}>
                                     <CSVLink filename={facetName} headers={headers} data={this.props.aggregations[key['field']]} >
                                         <i className="fa fa-download" aria-hidden="true"></i>


### PR DESCRIPTION
The selected aggregations are now added from the query's selection, not the currently visible facets. This resulted in facets with 0 results to disappear. Now (0) is displayed if a facet doesn't return any results