### PR TITLE
fix layout issue on query name component not aligning correctly in modal

### DIFF
--- a/sass/search/QueryEditor.scss
+++ b/sass/search/QueryEditor.scss
@@ -2,4 +2,7 @@
 	.bg__qed__table {
 		padding: 15px;
 	}
+	.form-group {
+		padding: 0 15px;
+	}
 }


### PR DESCRIPTION
fix layout issue:
Github issue: https://app.zenhub.com/workspace/o/clariah/wp5_mediasuite/issues/497

<img width="829" alt="screen shot 2018-08-21 at 16 08 45" src="https://user-images.githubusercontent.com/5918438/44406878-04733200-a55d-11e8-8948-2beac873ac76.png">
