### PR TITLE
PR: solved bug - sorting not working on dates in the Workspace

### DIFF
--- a/app/ItemDetailsRecipe.jsx
+++ b/app/ItemDetailsRecipe.jsx
@@ -236,7 +236,6 @@ class ItemDetailsRecipe extends React.Component {
 		if(itemDetailData && itemDetailData.playableContent) {
 			const mediaObject = itemDetailData.playableContent[index];
 			if(mediaObject) {
-				console.debug('generating annotation target for: ', mediaObject)
 				const annotation = AnnotationUtil.generateW3CEmptyAnnotation(
 					this.props.user,
 					this.state.activeProject,

--- a/app/collection/mappings/CollectionConfig.js
+++ b/app/collection/mappings/CollectionConfig.js
@@ -296,6 +296,11 @@ class CollectionConfig {
 		return null;
 	}
 
+	// returns the date as a single value to use in sorting.
+	getInitialDate(date) {
+	    return date;
+    }
+
 	//if the data has translations within its metadata
 	getPreferredLanguage() {
 		return null;

--- a/app/collection/mappings/CollectionConfig.js
+++ b/app/collection/mappings/CollectionConfig.js
@@ -298,7 +298,7 @@ class CollectionConfig {
 
 	// returns the date as a single value to use in sorting.
 	getInitialDate(date) {
-	    return date;
+	    return date ? date : null;
     }
 
 	//if the data has translations within its metadata

--- a/app/components/workspace/projects/bookmark/BookmarkTable.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkTable.jsx
@@ -1,9 +1,7 @@
-import ProjectAPI from '../../../../api/ProjectAPI';
 import AnnotationAPI from '../../../../api/AnnotationAPI';
 
 import IDUtil from '../../../../util/IDUtil';
 import ComponentUtil from '../../../../util/ComponentUtil';
-//import BookmarkUtil from '../../../../util/BookmarkUtil';
 
 import AnnotationStore from '../../../../flux/AnnotationStore';
 
@@ -245,30 +243,26 @@ class BookmarkTable extends React.PureComponent {
     }
 
     sortBookmarks(bookmarks, field) {
-        let collectionInfo = null;
         const sorted = bookmarks;
 
         // Enhance the bookmarks with a formatted date to allow sorting.
         sorted.map((item) => {
-            collectionInfo = CollectionUtil.generateCollectionConfig(
-               this.props.user.id,
-               this.props.user.name,
-               item.object.dataset,
-               config => {
-                  item.object.formattedDate = config.getInitialDate(item.object.date) || null;
-               },
-               true
-           );
+            const collectionClass = CollectionUtil.getCollectionClass(this.props.user.id, this.props.user.name, item.object.dataset, true);
+            if(collectionClass) {
+                item.object.formattedDate = collectionClass.prototype.getInitialDate(item.object.date)
+            }
         });
 
         const getFirst = (a, empty)=>(
             a.length > 0 ? a[0] : empty
         );
-        const sortOnNull = (order, a,b) => {
-            if(order === 'newest'){
-                return (a.object.formattedDate===null)-(b.object.formattedDate===null) || -(a.object.formattedDate>b.object.formattedDate)||+(a.object.formattedDate<b.object.formattedDate);
+        const sortOnNull = (order, a, b) => {
+            if (order === 'newest') {
+                return (a.object.formattedDate === null) - (b.object.formattedDate === null)
+                    || -(a.object.formattedDate > b.object.formattedDate) || +(a.object.formattedDate < b.object.formattedDate);
             }
-            return (a.object.formattedDate ===null)-(b.object.formattedDate===null) || +(a.object.formattedDate>b.object.formattedDate)||-(a.object.formattedDate<b.object.formattedDate);
+            return (a.object.formattedDate === null) - (b.object.formattedDate === null)
+                || +(a.object.formattedDate > b.object.formattedDate) || -(a.object.formattedDate < b.object.formattedDate);
         };
 
         switch (field) {
@@ -516,8 +510,8 @@ class BookmarkTable extends React.PureComponent {
                             onView={this.viewBookmark}
                             selected={
                                 this.state.selection.find(
-                                    item => item.resourceId == bookmark.resourceId
-                                ) != undefined
+                                    item => item.resourceId === bookmark.resourceId
+                                ) !== undefined
                             }
                             onSelect={this.selectItem}
                             showSubMediaObject={bookmark.resourceId in this.state.subMediaObject}

--- a/app/components/workspace/projects/bookmark/BookmarkTable.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkTable.jsx
@@ -253,8 +253,8 @@ class BookmarkTable extends React.PureComponent {
             }
         });
 
-        const getFirst = (a, empty)=>(
-            a.length > 0 ? a[0] : empty
+        const getFirst = (a, empty)=> (
+            a && a.length > 0 ? a[0] : empty
         );
         const sortOnNull = (order, a, b) => {
             if (order === 'newest') {

--- a/app/components/workspace/projects/bookmark/BookmarkTable.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkTable.jsx
@@ -243,14 +243,18 @@ class BookmarkTable extends React.PureComponent {
     }
 
     sortBookmarks(bookmarks, field) {
-        const sorted = bookmarks;
-
+        if(!bookmarks) {
+            return [];
+        }
         // Enhance the bookmarks with a formatted date to allow sorting.
-        sorted.map((item) => {
-            const collectionClass = CollectionUtil.getCollectionClass(this.props.user.id, this.props.user.name, item.object.dataset, true);
+        const sorted = bookmarks.map((item) => {
+            const collectionClass = CollectionUtil.getCollectionClass(
+                this.props.user.id, this.props.user.name, item.object.dataset, true
+            );
             if(collectionClass) {
                 item.object.formattedDate = collectionClass.prototype.getInitialDate(item.object.date)
             }
+            return item
         });
 
         const getFirst = (a, empty)=> (
@@ -470,8 +474,9 @@ class BookmarkTable extends React.PureComponent {
     }
 
     renderResults(renderState) {
-        const annotationTypeFilter = renderState.filter.annotations && !['yes','no'].includes(renderState.filter.annotations) ?
-            renderState.filter.annotations : '';
+        const annotationTypeFilter = renderState.filter.annotations && !['yes','no'].includes(
+            renderState.filter.annotations
+        ) ? renderState.filter.annotations : '';
         return (
             <div>
                 <h2>
@@ -479,7 +484,7 @@ class BookmarkTable extends React.PureComponent {
                         type="checkbox"
                         checked={
                             renderState.visibleItems.length > 0 && renderState.visibleItems.every(item =>
-                                this.state.selection.includes(item.resourceId)
+                                item && this.state.selection.includes(item.resourceId)
                             )
                         }
                         onChange={this.selectAllChange.bind(this, renderState.visibleItems)}/>

--- a/webpack_envs/webpack.development.js
+++ b/webpack_envs/webpack.development.js
@@ -12,7 +12,7 @@ module.exports = {
         libraryTarget: 'umd',
         library: 'labo'
     },
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
     module: {
         rules: [
             {


### PR DESCRIPTION
Issues: 
MEDIA column sorting breaks when no media value is present in record showing a Javascript error Cannot read property 'length' of undefined). 
Now a check to be sure that the object exists is done.

Because Date format not being sanitized Sorting by "Oldest/Newest objects first" doesn't sort properly the DATE column.

Examples of date formats found:

open-beelden-eye
1913-01-01
id: "dd93bd6b-8aa3-465e-9a3c-e1df16fbecf4"

"dans-oral-history"
id: "oai:easy.dans.knaw.nl:easy-dataset:50198"
"2012-06-05"

"dans-oral-history"
"2016"

dans-oral-history 
2016
oai:easy.dans.knaw.nl:easy-dataset:64205

"nisv-catalogue-aggr-full-18-158"
id: "4650154@program"
"16-08-1996 / 16-08-1996"

eye-desmet-papers4 
1921-1923
MMFMA01_PM_008065

"eye-desmet-films"
"1911  ([circa])"
id: "FLM4636"

"eye-desmet-films"
date: "1910 - 1919  ([circa])"
id: "FLM43941"

"nisv-catalogue-tv"
date: null
dateField: null
id: "5268418@program"
PS: even though date is available in itemDetails. 

dataset: "eye-desmet-affiches"
date: "1910 - 1919  ([?])"

Changes done to CollectionConfig and mapping files 
