### PR TITLE
#184 Fix bug in Graphs when in Search recipe

### DIFF
--- a/app/components/search/QueryBuilder.jsx
+++ b/app/components/search/QueryBuilder.jsx
@@ -245,7 +245,7 @@ class QueryBuilder extends React.Component {
             	{
 	            	//so involved components know that a new search was done
 	            	searchId: data.searchId,
-
+                    graphType : 'histogram',  // on new search resets graph to histogram.
 	            	//refresh params of the query object
 	            	query : data.query,
 


### PR DESCRIPTION
Fix issue when in Search recipe:
When switching  graphs to relative view and then updating query search the app breaks after switching graphs again. 
Check screencast in:
https://app.zenhub.com/workspaces/main-board-5bd99e4e4b5806bc2befbe27/issues/beeldengeluid/labo-components/184  