### PR TITLE
#195 Format Date field in Workspace bookmark table

### DIFF
--- a/app/components/workspace/projects/bookmark/BookmarkRow.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkRow.jsx
@@ -75,7 +75,9 @@ class BookmarkRow extends React.PureComponent {
                     {annotations.map(annotation => (
                         <tr>
                             <td className="type bold">
-                                <Link to={'/workspace/projects/' + this.props.projectId + '/annotations#' + annotation.annotationType + '-centric'}>{AnnotationTranslator(annotation.annotationType)}</Link>
+                                <Link to={'/workspace/projects/' + this.props.projectId + '/annotations#' + annotation.annotationType + '-centric'}>
+                                    {AnnotationTranslator(annotation.annotationType)}
+                                </Link>
                             </td>
                             <td className="content">
                                 {annotation.text ? annotation.text.substring(0, 200) : null}
@@ -84,7 +86,11 @@ class BookmarkRow extends React.PureComponent {
                             <td className="details">
                                 {annotation.vocabulary ? 'Vocabulary: ' + annotation.vocabulary : null}
                                 {annotation.annotationType === 'comment' ? annotation.created : null}
-                                {annotation.url ? <a rel="noopener noreferrer" target="_blank" href={'https:'+annotation.url}>{annotation.url ? annotation.url.replace(/^\/\//i,"") : ""}</a> : null}
+                                {annotation.url ?
+                                    <a rel="noopener noreferrer" target="_blank" href={'https:'+annotation.url}>
+                                        {annotation.url ? annotation.url.replace(/^\/\//i,"") : ""}
+                                    </a> : null
+                                }
                                 {annotation.annotationTemplate ? 'Template: ' + annotation.annotationTemplate : null}
                             </td>
                         </tr>
@@ -180,9 +186,9 @@ class BookmarkRow extends React.PureComponent {
         let resourceDate = null;
         if(bookmark.object.date) {
             if(bookmark.object.date.match(/^\d/)) {
-                resourceDate = bookmark.object.date.replace( /[^0-9-]/g, '' ).substring(0, 10);
+                resourceDate = bookmark.object.date.replace(/[^0-9-]/g, '').substring(0, 10);
             } else {
-                resourceDate = bookmark.object.date.replace( /[^0-9-]/g, '' );
+                resourceDate = bookmark.object.date.replace(/[^0-9-]/g, '');
             }
         }
         return (
@@ -196,7 +202,10 @@ class BookmarkRow extends React.PureComponent {
                             title={'Select this bookmark with resource ID:\n' + bookmark.resourceId}/>
                     </div>
 
-                    <div className="image" title={"Resource ID: " + bookmark.resourceId} onClick={this.onView} style={{backgroundImage: 'url(' + bookmark.object.placeholderImage + ')'}}/>
+                    <div className="image"
+                        title={"Resource ID: " + bookmark.resourceId} onClick={this.onView}
+                        style={{backgroundImage: 'url(' + bookmark.object.placeholderImage + ')'}}
+                    />
 
                     <ul className="info">
                         <li className="primary content-title">

--- a/app/components/workspace/projects/bookmark/BookmarkRow.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkRow.jsx
@@ -180,9 +180,9 @@ class BookmarkRow extends React.PureComponent {
         let resourceDate = null;
         if(bookmark.object.date) {
             if(bookmark.object.date.match(/^\d/)) {
-                resourceDate = bookmark.object.date.substring(0, 10);
+                resourceDate = bookmark.object.date.replace( /[^0-9-]/g, '' ).substring(0, 10);
             } else {
-                resourceDate = bookmark.object.date
+                resourceDate = bookmark.object.date.replace( /[^0-9-]/g, '' );
             }
         }
         return (


### PR DESCRIPTION
Issue: task/#195-format-date-field-in-workspace-bookmark-table

Currently the Date field in the bookmark's table of the Workspace filters by displaying the first 10 characters starting with a number which leaves incomplete dates when there are spaces in between numbers.
The replacement rule has been modified to remove spaces before trunking the date and also removes characters from the date field to avoid issues like displaying text in dates, for example:
1911 ([cir
1993 (comp