### PR TITLE
Issue 181, 217 and 170

### DIFF
--- a/app/ItemDetailsRecipe.jsx
+++ b/app/ItemDetailsRecipe.jsx
@@ -192,12 +192,16 @@ class ItemDetailsRecipe extends React.Component {
 						};
 						//TODO make sure this works for all carriers!!
 						if (config.requiresPlayoutAccess() && itemDetailData.playableContent) {
-							PlayoutAPI.requestAccess(
+						    if (itemDetailData.playableContent.length > 0){
+						        PlayoutAPI.requestAccess(
 								itemDetailData.playableContent[0].contentServerId,
 								itemDetailData.playableContent[0].contentId,
 								desiredState,
 								this.onLoadPlayoutAccess.bind(this)
-							)
+							    )
+						    } else {
+						        this.setState(desiredState);
+						    }
 						} else {
 							this.setState(desiredState);
 						}

--- a/app/SingleSearchRecipe.jsx
+++ b/app/SingleSearchRecipe.jsx
@@ -100,10 +100,10 @@ class SingleSearchRecipe extends React.Component {
 		//always refresh the saved bookmarks on load, since they could have been updated in
 		//either the workspace or the resource viewer
 		this.saveBookmarksToLocalStorage();
-		
+
 		if(!loadingFromWorkSpace) {
 			this.onReloadQueryData(collectionId, initialQuery);
-		}		
+		}
 	}
     // current bookmarks per project
 	saveBookmarksToLocalStorage() {
@@ -112,7 +112,6 @@ class SingleSearchRecipe extends React.Component {
                 this.props.user.id,
                 this.state.activeProject.id,
                 (data) => {
-                	console.debug('latest bookmarks', data);
                 	ComponentUtil.storeJSONInLocalStorage('activeBookmarks', data)
                 }
             ) :
@@ -203,7 +202,7 @@ class SingleSearchRecipe extends React.Component {
 		} else if(componentClass === 'BookmarkSelector') {
 			if(data && data.allGroups && data.selectedGroups) {
 				this.bookmarkToGroupInProject(data.allGroups, data.selectedGroups);
-			}			
+			}
 		} else if(componentClass === 'QueryEditor') {
 			this.onQuerySaved(data)
 		}
@@ -411,7 +410,7 @@ class SingleSearchRecipe extends React.Component {
             showBookmarkedItems : false
 		});
 	}
-    
+
     // makes sure that all selected resources are ADDED to the selected groups
 	bookmarkToGroupInProject(allGroups, selectedGroups) {
         const selectedRows = ComponentUtil.getJSONFromLocalStorage('selectedRows');
@@ -432,17 +431,17 @@ class SingleSearchRecipe extends React.Component {
 						temp[t.source] = true;
 						dedupedTargets.push(t);
 					}
-				});				
+				});
 				group.target = dedupedTargets;
-				
+
 				//FIXME this code is not entirely safe: what if somehow the saveAnnotation does not return?
-				AnnotationAPI.saveAnnotation(group, () => {					
+				AnnotationAPI.saveAnnotation(group, () => {
 					if(++saveCount == Object.keys(selectedGroups).length) {
 						this.onSaveBookmarks();
 					}
 				});
         	});
-            
+
 		});
 	}
 

--- a/app/collection/mappings/CollectionConfig.js
+++ b/app/collection/mappings/CollectionConfig.js
@@ -299,6 +299,11 @@ class CollectionConfig {
 		return null;
 	}
 
+	// returns the date as a single value to use in sorting.
+	getInitialDate(date) {
+	    return date ? date : null;
+    }
+
 	//if the data has translations within its metadata
 	getPreferredLanguage() {
 		return null;
@@ -392,7 +397,7 @@ class CollectionConfig {
 			result.start = result._source.start ? result._source.start : 0;
 			result.end = result._source.end ? result._source.end : -1;
 		}
-		if(result.playableContent){
+		if(result.playableContent && result.playableContent.length > 0){
 		    snippet['playable'] = true;
 		} else
 		    snippet['playable']= false;

--- a/app/collection/mappings/CollectionConfig.js
+++ b/app/collection/mappings/CollectionConfig.js
@@ -377,7 +377,7 @@ class CollectionConfig {
 
 	//the result object passed here was passed through getItemDetailData, so all possible data has already been extracted (bit ugly)
 	getResultSnippetData(result) {
-		const snippet = {
+	    const snippet = {
 			id : result.resourceId,
 			type : result.docType,
 			title: result.title || 'No title for: ' + result.resourceId + '',
@@ -392,6 +392,10 @@ class CollectionConfig {
 			result.start = result._source.start ? result._source.start : 0;
 			result.end = result._source.end ? result._source.end : -1;
 		}
+		if(result.playableContent){
+		    snippet['playable'] = true;
+		} else
+		    snippet['playable']= false;
 		return snippet;
 	}
 

--- a/app/components/search/SearchSnippet.jsx
+++ b/app/components/search/SearchSnippet.jsx
@@ -93,7 +93,7 @@ class SearchSnippet extends React.Component {
 			});
 
 			//Note: assigning a media type (to the result data) automatically means it's accessible in the media suite!
-			if(this.props.data.mediaTypes.length > 0) {
+			if(this.props.data.playable) {
 				accessIcon = (
 					<span
 						className={IconUtil.getMediaObjectAccessIcon(true, true, true, true, false)}

--- a/app/components/search/SearchSnippet.jsx
+++ b/app/components/search/SearchSnippet.jsx
@@ -2,6 +2,7 @@
 
 import IconUtil from '../../util/IconUtil';
 import IDUtil from '../../util/IDUtil';
+import RegexUtil from '../../util/RegexUtil';
 import CollectionUtil from '../../util/CollectionUtil';
 import Classification from '../annotation/Classification';
 
@@ -24,18 +25,22 @@ class SearchSnippet extends React.Component {
 
     highlightSearchedTerm(text) {
 		if(text === null) {
-		 	return text
+		 	return text;
 		}
-        let regex = new RegExp(this.stripQuotes(this.props.searchTerm), 'gi');
-        return text.replace(regex, (term) => "<span class='highLightText'>" + term + "</span>");
-    }
+		if(this.props.searchTerm){
+            let regex = RegexUtil.generateRegexForSearchTerm(this.props.searchTerm);
+            return text.replace(regex, (term) => "<span class='highLightText'>" + term + "</span>");
+		} else {
+		    return text;
+		}
+	}
 
-    stripQuotes(str) {
-    	if(str.startsWith('"') && str.endsWith('"') && str.length > 2) {
-			return str.substring(1, str.length -1)
-		}
-		return str
-    }
+//    stripQuotes(str) {
+//    	if(str.startsWith('"') && str.endsWith('"') && str.length > 2) {
+//			return str.substring(1, str.length -1)
+//		}
+//		return str
+//    }
 
     createMarkup(text){
 		return {__html: text}
@@ -134,10 +139,7 @@ class SearchSnippet extends React.Component {
 					</h4>
 					<span className="snippet_description" dangerouslySetInnerHTML={this.createMarkup(
                         this.highlightSearchedTerm(CollectionUtil.highlightSearchTermInDescription(
-                            this.props.data.description,
-                            this.stripQuotes(this.props.searchTerm),
-                            35
-                        ))
+                            this.props.data.description, this.props.searchTerm, 35))
 					)} />
 					{fragmentInfo}
 					{tags}

--- a/app/components/workspace/projects/bookmark/BookmarkRow.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkRow.jsx
@@ -74,7 +74,7 @@ class BookmarkRow extends React.PureComponent {
                 </thead>
                 : null}
                 <tbody>
-                    {annotations.map(annotation => {                        
+                    {annotations.map(annotation => {
                         return (
                             <tr>
                                 <td className="type bold">
@@ -187,7 +187,7 @@ class BookmarkRow extends React.PureComponent {
 
         //format the date of the resource/target (i.e. bookmark.object)
         let resourceDate = null;
-        if(bookmark.object.date) {
+        if(bookmark.object.date && typeof(bookmark.object.date) === 'string')  {
             if(bookmark.object.date.match(/^\d/)) {
                 resourceDate = bookmark.object.date.replace(/[^0-9-]/g, '').substring(0, 10);
             } else {

--- a/app/components/workspace/projects/bookmark/BookmarkRow.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkRow.jsx
@@ -1,6 +1,7 @@
 import ProjectAPI from '../../../../api/ProjectAPI';
 
 import IDUtil from '../../../../util/IDUtil';
+import IconUtil from '../../../../util/IconUtil';
 
 import {secToTime} from '../../helpers/time';
 import {AnnotationTranslator} from '../../helpers/AnnotationTranslator';
@@ -185,6 +186,37 @@ class BookmarkRow extends React.PureComponent {
                 resourceDate = bookmark.object.date
             }
         }
+
+        //show the user what media can be expected
+        let mediaIcon = null;
+        let playableIcon = (
+			<span
+				className={IconUtil.getMediaObjectAccessIcon(false, false, true, true, false)}
+				title="Media object(s) not accessible">
+			</span>
+		);
+		if(bookmark.object.mediaTypes) {
+			mediaIcon = bookmark.object.mediaTypes.map((mt) => {
+				if(mt == 'video') {
+					return (<span className={IconUtil.getMimeTypeIcon('video', true, true, false)} title="Video content"></span>);
+				} else if(mt == 'audio') {
+					return (<span className={IconUtil.getMimeTypeIcon('audio', true, true, false)} title="Audio content"></span>);
+				} else if(mt == 'image') {
+					return (<span className={IconUtil.getMimeTypeIcon('image', true, true, false)} title="Image content"></span>);
+				} else if(mt == 'text') {
+					return (<span className={IconUtil.getMimeTypeIcon('text', true, true, false)} title="Textual content"></span>);
+ 				}
+			});
+		}
+		if(bookmark.object.playable) {
+            playableIcon = (
+                <span
+                    className={IconUtil.getMediaObjectAccessIcon(true, true, true, true, false)}
+                    title="Media object(s) can be viewed">
+                </span>
+            );
+		}
+
         return (
             <div className={classNames(IDUtil.cssClassName('bookmark-row'), 'item-row')}>
                 <div className="item">
@@ -210,8 +242,9 @@ class BookmarkRow extends React.PureComponent {
                             <p title={bookmark.object.dateField}>{resourceDate}</p>
                         </li>
                         <li className="content-media">
-                            <h4 className="label">Media</h4>
-                            <p>{bookmark.object.mediaTypes ? bookmark.object.mediaTypes.join(",") : 'Unknown'}</p>
+                            <h4 className="label">Media info</h4>
+                            {/*<p>{bookmark.object.mediaTypes ? bookmark.object.mediaTypes.join(",") : 'Unknown'}</p>-->*/}
+                            <p>{mediaIcon} {playableIcon}</p>
                         </li>
                         <li className="content-dataset">
                             <h4 className="label">Dataset</h4>

--- a/app/components/workspace/projects/bookmark/BookmarkTable.jsx
+++ b/app/components/workspace/projects/bookmark/BookmarkTable.jsx
@@ -39,6 +39,7 @@ class BookmarkTable extends React.PureComponent {
             { value: 'name-az', name: 'Title A-Z' },
             { value: 'name-za', name: 'Title Z-A' },
             { value: 'mediatype', name: 'Media' },
+            { value: 'playable', name: 'Playable'},
             { value: 'dataset', name: 'Dataset' },
             { value: 'group', name: 'Groups' },
         ];
@@ -237,9 +238,6 @@ class BookmarkTable extends React.PureComponent {
                 );
             });
         }
-
-
-
         return bookmarks;
     }
 
@@ -271,6 +269,8 @@ class BookmarkTable extends React.PureComponent {
                     sorted.sort((a, b) => getFirst(a.object.mediaTypes, e) > getFirst(b.object.mediaTypes, e) ? 1 : -1);
                     break;
                 }
+            case 'playable':
+                sorted.sort((a, b) => a.object.playable < b.object.playable ? -1 : 1);
             case 'dataset':
                 sorted.sort((a, b) => a.object.dataset > b.object.dataset ? 1 : -1);
                 break;

--- a/app/util/CollectionUtil.js
+++ b/app/util/CollectionUtil.js
@@ -17,6 +17,7 @@ import CollectionAPI from '../api/CollectionAPI';
 import CKANAPI from '../api/CKANAPI';
 
 import TimeUtil from '../util/TimeUtil';
+import RegexUtil from '../util/RegexUtil';
 
 import CollectionConfig from '../collection/mappings/CollectionConfig';
 import CollectionMapping from '../collection/mappings/CollectionMapping';
@@ -146,9 +147,13 @@ const CollectionUtil = {
 	//for pruning long descriptions; makes sure to return the snippet that contains the search term
 	highlightSearchTermInDescription(text, searchTerm=null, maxWords=35) {
 		if(text) {
+		    if(Array.isArray(text)) {
+		        text = text.join('\n');
+		    }
 			let index = 0;
 			if(searchTerm) {
-				const regex = new RegExp(searchTerm.toLowerCase(), 'gi');
+				//const regex = new RegExp(searchTerm.toLowerCase(), 'gi');
+				const regex = RegexUtil.generateRegexForSearchTerm(searchTerm);
 				index = text.toLowerCase().search(regex);
 			}
 			index = index > 50 ? index - 50 : 0;

--- a/app/util/RegexUtil.js
+++ b/app/util/RegexUtil.js
@@ -1,0 +1,18 @@
+const RegexUtil = {
+
+    generateRegexForSearchTerm(searchTerm) {
+        var searchTerm = RegexUtil.escapeRegExp(searchTerm);
+        var splitTerms = searchTerm.match(/\w+|\"([^\"]+)\"/gi);
+        for (var i = 0; i < splitTerms.length; i++) {
+            splitTerms[i] = splitTerms[i].replace(/\"/g, "");
+        }
+        console.log(splitTerms);
+        let regex = new RegExp(splitTerms.join("|"), 'gi');
+        return regex;
+    },
+
+    escapeRegExp(text) {
+        return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+}
+export default RegexUtil;

--- a/app/util/RegexUtil.js
+++ b/app/util/RegexUtil.js
@@ -6,7 +6,6 @@ const RegexUtil = {
         for (var i = 0; i < splitTerms.length; i++) {
             splitTerms[i] = splitTerms[i].replace(/\"/g, "");
         }
-        console.log(splitTerms);
         let regex = new RegExp(splitTerms.join("|"), 'gi');
         return regex;
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labo-components",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "B&G UI components",
   "main": "webpack.config.js",
   "scripts": {

--- a/sass/workspace/style/_reset.scss
+++ b/sass/workspace/style/_reset.scss
@@ -3,7 +3,7 @@ div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
+  //font: inherit;
   vertical-align: middle;
   text-align: inherit;
   border-radius: 0;


### PR DESCRIPTION
This update allows several things:

Issue 181:
- Shows the icon of a mediatype separately from the accessible icon
- Shows the same icons in the search snippets also in the bookmark view in the workspace

Issue 217:
- Non alphanumerical characters are removed/escaped from the search query. This fixes the bug mentioned in this issue

Issue 170:
- The highlighting of search terms is now based on a more elaborate regex instead of just the search string. Multiple words are now independently highlighted unless the user puts quotes around them. 