### PR TITLE
Update Collection Selector css to acount for long images

### DIFF
--- a/sass/collection/CollectionSelector.scss
+++ b/sass/collection/CollectionSelector.scss
@@ -3,7 +3,7 @@
         border-bottom: 1px solid #d3d3d3;
 		border-radius: $border-radius;
 		float: left;
-		height: 240px;
+		height: 260px;
 		margin: 1% 1% 1% 1%;
 		overflow: hidden;
 		padding: 10px;


### PR DESCRIPTION
Issue:
Long icon images for collections make the Read more link usable.
<img width="619" alt="Screenshot 2019-04-02 at 13 28 44" src="https://user-images.githubusercontent.com/5918438/55399411-57798280-554b-11e9-89da-9b9ba24d9c73.png">

No issue in github created for this small change