### PR TITLE
Show selected aggregations on top of selection block group

### DIFF
--- a/app/components/search/AggregationList.jsx
+++ b/app/components/search/AggregationList.jsx
@@ -293,7 +293,7 @@ class AggregationList extends React.Component {
                 );
                 // filter out the selected ones
                 facets = facets.filter(f => !f.selected);
-                facets.push(...selectedFacets);
+                facets.unshift(...selectedFacets);
             }
 
             //then add them to the convenient UI object (together with the exclusion property)


### PR DESCRIPTION
@jblom 
Show selected aggregations on top of selection block group.
No issue created in github.
### Issue 
When selecting aggregations the checked element goes to the bottom of the list (see screenshot)
![Screenshot 2019-04-02 at 14 03 24](https://user-images.githubusercontent.com/5918438/55401170-39fae780-5550-11e9-9092-31c0aac88e05.png)

### Done
Now whenever an aggregation is selected it goes to the top of the aggregation block 
<img width="307" alt="Screenshot 2019-04-02 at 14 04 36" src="https://user-images.githubusercontent.com/5918438/55401224-644ca500-5550-11e9-92cc-ba0bd3deea19.png">
